### PR TITLE
Turn on Google Analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,5 +38,5 @@ plugins:
 color_scheme: umass
 
 # Google Analytics Tracking (optional)
-# e.g, UA-1234567-89
-# ga_tracking: G-MVHTPQ8CLM
+# Supports a CSV of tracking ID strings (eg. "UA-1234567-89,G-1AB234CDE5")
+ga_tracking: G-MVHTPQ8CLM

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -22,6 +22,7 @@
   {% include css/activation.scss.liquid %}
   </style>
 
+  <!--Google Analytics tracking code-->
   {% if site.ga_tracking != nil %}
     {% assign ga_tracking_ids = site.ga_tracking | split: "," %}
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ ga_tracking_ids.first }}"></script>


### PR DESCRIPTION
Google Analytics was tracking the site up until 10/7/23, following a site update to the latest just-the-docs version (#27). That update removed the embedded GA code from `head.html`. The script now requires the GA code to be named as a variable in `_config.yml`. This PR reactivates the variable.