### PR TITLE
update pages actions

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
         with:
@@ -49,7 +49,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-artifact@v4
 
   # Deployment job
   deploy:


### PR DESCRIPTION
The `Jekyll site to Pages` action failed, giving the error "Error: Missing download info for actions/upload-artifact@v3." I followed the steps in this discussion post to update the actions: https://github.com/orgs/community/discussions/152695 