### PR TITLE
Fix nav for georeferencing tutorial

### DIFF
--- a/content/georeferencing/georeferencing-advanced.md
+++ b/content/georeferencing/georeferencing-advanced.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Advanced Concepts
-parent: Georeference a Historical Map
+parent: Georeference an Image
 nav_order: 4
 ---
 

--- a/content/georeferencing/georeferencing-basics.md
+++ b/content/georeferencing/georeferencing-basics.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Georeferencing Basics
-parent: Georeference a Historical Map
+parent: Georeference an Image
 nav_order: 2
 ---
 

--- a/content/georeferencing/online-tools.md
+++ b/content/georeferencing/online-tools.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Using an Online Tool
-parent: Georeference a Historical Map
+parent: Georeference an Image
 nav_order: 3
 ---
 

--- a/content/georeferencing/tutorial.md
+++ b/content/georeferencing/tutorial.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Tutorial
-parent: Georeference a Historical Map
+parent: Georeference an Image
 nav_order: 5
 ---
 


### PR DESCRIPTION
I changed the name of the georeferencing tutorial, which broke the nav bar. This fixes that.